### PR TITLE
Update changelog for PingOne user info bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2020-08-21
+- 🐛 Bug fix: SSO users should see their name and avatar in Studio now (provided they've set up the attribute mapping via PingOne)
+
 ## 2020-08-20
 - 🐛 Bug fix: schema checks no longer skip anonymous operations
 


### PR DESCRIPTION
We recently landed changes to properly fetch the name and avatar of PingOne/SSO users. (Note that this only works if the user has set up the attribute mapping in PingOne.)