### PR TITLE
Add warning img comment to top of CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+[comment]: <> (NOTE! Ensure all images are added via the \[label\]\(link\) syntax!)
+
 ## 2022-08-01 
 | What's new | |
 | :--------- | :-: |


### PR DESCRIPTION
Warn folks that all images should be added with the `[]()` syntax