### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2022-10-25
 | What's new | 
 | :--------- |
-| Enhancements to the Schema Checks algorithm now detect breaking changes in more cases, such as when accessing enum values, interface fields, and union fields via a list.  Additionally, checks will fail in more cases when NO operations are recorded in Studio to be checked against, as per the [documentation on schema checks](https://www.apollographql.com/docs/graphos/schema-checks/#the-check-response).
+| We've made some enhancements to the Schema Checks algorithm which allow for detecting breaking changes in more cases, such as when accessing enum values, interface fields, and union fields via a list.  Additionally, checks will fail in more cases when NO operations are recorded in Studio to be checked against, as per the [documentation on schema checks](https://www.apollographql.com/docs/graphos/schema-checks/#the-check-response).
 
 ## 2022-10-21 Offline Sandbox now only accessible in embedded contexts
 | What's new | 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2022-10-25
+| What's new | 
+| :--------- |
+| Enhancements to the Schema Checks algorithm now detect breaking changes in more cases, such as when accessing enum values, interface fields, and union fields via a list.  Additionally, checks will fail in more cases when NO operations are recorded in Studio to be checked against, as per the [documentation on schema checks](https://www.apollographql.com/docs/graphos/schema-checks/#the-check-response).
+
 ## 2022-10-21 Offline Sandbox now only accessible in embedded contexts
 | What's new | 
 | :--------- |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2022-10-25
 | What's new | 
 | :--------- |
-| We've made some enhancements to the Schema Checks algorithm which allow for detecting breaking changes in more cases, such as when accessing enum values, interface fields, and union fields via a list.  Additionally, checks will fail in more cases when NO operations are recorded in Studio to be checked against, as per the [documentation on schema checks](https://www.apollographql.com/docs/graphos/schema-checks/#the-check-response).
+| Schema checks now detect breaking changes in more cases, such as for enum values, interface fields, and union fields on a list. In addition, schema checks on operations will now fail if one or more subgraphs in the check do not have recorded operations in Studio. [Learn more in the schema checks docs](https://www.apollographql.com/docs/graphos/schema-checks/#the-check-response).
 
 ## 2022-10-21 Offline Sandbox now only accessible in embedded contexts
 | What's new | 


### PR DESCRIPTION
We've made some enhancements to the Schema Checks algorithm which allow for detecting breaking changes in more cases, such as when accessing enum values, interface fields, and union fields via a list.  Additionally, checks will fail in more cases when NO operations are recorded in Studio to be checked against, as per the [documentation on schema checks](https://www.apollographql.com/docs/graphos/schema-checks/#the-check-response).