### PR TITLE
🐛 Hide comment at top of changelog from studio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-[comment]: <> (NOTE! Ensure all images are added via the \[label\]\(link\) syntax!)
+[comment]: <> "NOTE! Ensure all images are added via the \[label\]\(link\) syntax!"
 
 ## 2023-03-07
 | What's new | |


### PR DESCRIPTION
Our markdown renderer is not picking up that the comment at the top of the document is actually a comment and renders it with the rest of the changelog items.
![Screenshot 2023-03-07 at 1 33 15 PM](https://user-images.githubusercontent.com/24704789/223517335-c8c677ee-7ca0-41ae-a54d-c7f313ebef96.png)

Changing the parentheses to quotation marks *should* fix this issue.

