### PR TITLE
Fix CHANGELOG formatting of last update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 [comment]: <> "NOTE! Ensure all images are added via the \[label\]\(link\) syntax!"
+
 ## 2024-09-30
+
 | What's new | |
 | :--------- | :-: |
 | [Custom schema checks](https://www.apollographql.com/docs/graphos/delivery/custom-checks/) are now available on enterprise plans. Go to Checks settings to register webhook handlers that run custom validations, such as custom lint rules, on your own services.  | ![image](https://github.com/user-attachments/assets/7c0f4165-6e7a-499b-aa47-076b0bd3f814)


### PR DESCRIPTION
Fix some formatting happeing in the Studio UI

The first line is being all put on one line

![Screenshot 2024-10-02 at 9 44 43 AM](https://github.com/user-attachments/assets/6a79c34e-700a-475f-bd9c-3a698d25524c)
